### PR TITLE
Update Xen to current aem-staging.

### DIFF
--- a/conf/distro/tb-xen-distro.conf
+++ b/conf/distro/tb-xen-distro.conf
@@ -9,9 +9,9 @@ IMAGE_EFI_BOOT_FILES += " \
     xen.cfg \
 "
 
-PREFERRED_VERSION_xen = "4.17+tb"
+PREFERRED_VERSION_xen = "4.22+tb"
 # TODO: for some reason, building tools from TB fork does not build all of the
 # tools - many basic binaries are missing
-PREFERRED_VERSION_xen-tools = "4.17+stable"
+PREFERRED_VERSION_xen-tools = "4.22+git"
 
 TB_GRUB_CFG_FILE = "grub-full.cfg"

--- a/dynamic-layers/virtualization-layer/recipes-extended/xen/files/0001-python-pygrub-pass-DISTUTILS-xen-4.20.patch
+++ b/dynamic-layers/virtualization-layer/recipes-extended/xen/files/0001-python-pygrub-pass-DISTUTILS-xen-4.20.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Pending
+
+Index: git/tools/pygrub/Makefile
+===================================================================
+--- git.orig/tools/pygrub/Makefile
++++ git/tools/pygrub/Makefile
+@@ -13,14 +13,14 @@ setup.py = CC="$(CC)" CFLAGS="$(PY_CFLAG
+ all: build
+ .PHONY: build
+ build:
+-	$(setup.py) build
++	$(setup.py) build $(DISTUTILS_BUILD_ARGS)
+ 
+ .PHONY: install
+ install: all
+ 	$(INSTALL_DIR) $(DESTDIR)/$(bindir)
+ 	$(INSTALL_DIR) $(DESTDIR)/$(LIBEXEC_BIN)
+ 	$(setup.py) install --record $(INSTALL_LOG) $(PYTHON_PREFIX_ARG) \
+-		--root="$(DESTDIR)" --force
++		--root="$(DESTDIR)" --force  $(DISTUTILS_INSTALL_ARGS)
+ 	$(INSTALL_PYTHON_PROG) src/pygrub $(DESTDIR)/$(LIBEXEC_BIN)/pygrub
+ 
+ .PHONY: uninstall
+Index: git/tools/python/Makefile
+===================================================================
+--- git.orig/tools/python/Makefile
++++ git/tools/python/Makefile
+@@ -16,13 +16,13 @@ setup.py = CC="$(CC)" CFLAGS="$(PY_CFLAG
+ 
+ .PHONY: build
+ build:
+-	$(setup.py) build
++	$(setup.py) build $(DISTUTILS_BUILD_ARGS)
+ 
+ .PHONY: install
+ install:
+ 	$(INSTALL_DIR) $(DESTDIR)$(LIBEXEC_BIN)
+ 	$(setup.py) install --record $(INSTALL_LOG) $(PYTHON_PREFIX_ARG) \
+-		--root="$(DESTDIR)" --force
++		--root="$(DESTDIR)" --force $(DISTUTILS_INSTALL_ARGS)
+ 	$(INSTALL_PYTHON_PROG) scripts/convert-legacy-stream $(DESTDIR)$(LIBEXEC_BIN)
+ 	$(INSTALL_PYTHON_PROG) scripts/verify-stream-v2 $(DESTDIR)$(LIBEXEC_BIN)
+ 

--- a/dynamic-layers/virtualization-layer/recipes-extended/xen/xen-tb.inc
+++ b/dynamic-layers/virtualization-layer/recipes-extended/xen/xen-tb.inc
@@ -4,10 +4,9 @@ PV = "${XEN_REL}+tb"
 
 SRC_URI = "git://github.com/TrenchBoot/xen.git;branch=${XEN_BRANCH};protocol=https"
 
-# v0.5.0 tag
-SRCREV = "ad7b5727bcde383957f69ff03a38ade1c82f531d"
+SRCREV = "2be6e3866b2f64c0b07ebd9266275825678c5d01"
 
 S = "${WORKDIR}/git"
 
-XEN_REL = "4.17"
-XEN_BRANCH = "aem-next"
+XEN_REL = "4.22"
+XEN_BRANCH = "aem-staging-2026-03-13"

--- a/dynamic-layers/virtualization-layer/recipes-extended/xen/xen-tools_git.bbappend
+++ b/dynamic-layers/virtualization-layer/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,0 +1,42 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:remove = "file://0001-python-pygrub-pass-DISTUTILS-xen-4.18.patch"
+SRC_URI:append = " file://0001-python-pygrub-pass-DISTUTILS-xen-4.20.patch"
+
+XEN_REL = "4.22"
+XEN_BRANCH = "staging"
+# nooelint: oelint.append.protvars
+SRCREV = "a3a1e61ce9a00c5a0c8003bad8f1285360399cf4"
+
+PACKAGES += " \
+    ${PN}-libxenmanage \
+    ${PN}-libxenmanage-dev \
+    ${PN}-xen-9pfsd \
+"
+
+FILES:${PN}-test += " \
+    ${libdir}/xen/tests/test-xenstore \
+    ${libdir}/xen/tests/test-rangeset \
+    ${libdir}/xen/tests/test-resource \
+    ${libdir}/xen/tests/test-domid \
+    ${libdir}/xen/tests/test-paging-mempool \
+    ${libdir}/xen/tests/test_vpci \
+    ${libdir}/xen/tests/test-pdx-offset \
+    ${libdir}/xen/tests/test-pdx-mask \
+    ${libdir}/xen/tests/test-cpu-policy \
+    ${libdir}/xen/tests/test-tsx \
+    ${libdir}/xen/tests/test-mem-claim \
+    ${libdir}/xen/tests/test_x86_emulator \
+"
+
+FILES:${PN}-staticdev += "${libdir}/libxenmanage.a"
+FILES:${PN}-xen-9pfsd += "${libdir}/xen/bin/xen-9pfsd"
+FILES:${PN}-xen-watchdog += "${systemd_unitdir}/system-sleep/xen-watchdog-sleep.sh"
+FILES:${PN}-libxenmanage += "${libdir}/libxenmanage.so.*"
+FILES:${PN}-libxenmanage-dev += " \
+    ${libdir}/libxenmanage.so \
+    ${libdir}/pkgconfig/xenmanage.pc \
+    ${datadir}/pkgconfig/xenmanage.pc \
+"
+
+RDEPENDS:${PN} += "${PN}-libxenmanage"

--- a/recipes-kernel/linux/linux-tb/0001-tpm_tis-extend-mmio-region-to-cover-all-localities.patch
+++ b/recipes-kernel/linux/linux-tb/0001-tpm_tis-extend-mmio-region-to-cover-all-localities.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Iwanicki?= <michal.iwanicki@3mdeb.com>
+Date: Mon, 16 Mar 2026 00:00:00 +0000
+Subject: [PATCH] tpm/tis: extend MMIO region to cover all TIS localities
+
+Some ACPI/PnP tables only declare a single TPM locality (0x1000
+bytes) even though the TIS spec requires 5 localities (TIS_MEM_LEN =
+0x5000 bytes). Since 6.12, tpm_tis_core_init probes all localities
+unconditionally, causing a page fault when the ioremap'd region is
+smaller than the accessed offset. Extend the resource to TIS_MEM_LEN
+here; the hardware always provides the full region at the standard
+base address even when the BIOS under-declares it.
+
+Reproducer: HP t630 Thin Client (BIOS M40 v01.05 07/07/2017) with
+kernel 6.13 crashes at boot:
+
+  BUG: unable to handle page fault for address: ffffa47140062000
+  tpm_tcg_read_bytes+0x51/0xb0
+  check_locality+0x4b/0x90
+  tpm_tis_core_init+0x301/0x910
+  tpm_tis_pnp_init+0xda/0x110
+
+The ACPI/PnP resource reports 0x1000 bytes (one locality). The
+driver maps only 0xFED40000-0xFED40FFF, then faults when
+check_locality(chip, 1) accesses TPM_ACCESS(1) = base + 0x1000.
+
+Upstream-Status: Pending
+Signed-off-by: Michał Iwanicki <michal.iwanicki@3mdeb.com>
+---
+ drivers/char/tpm/tpm_tis.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/char/tpm/tpm_tis.c b/drivers/char/tpm/tpm_tis.c
+index 9aa230a63..0e8564d6a 100644
+--- a/drivers/char/tpm/tpm_tis.c
++++ b/drivers/char/tpm/tpm_tis.c
+@@ -259,6 +259,23 @@ static int tpm_tis_pnp_init(struct pnp_dev *pnp_dev,
+ 		return -ENODEV;
+ 	tpm_info.res = *res;
+
++	/*
++	 * Some ACPI/PnP tables only declare a single TPM locality (0x1000
++	 * bytes) even though the TIS spec requires 5 localities (TIS_MEM_LEN =
++	 * 0x5000 bytes). Since 6.12, tpm_tis_core_init probes all localities
++	 * unconditionally, causing a page fault when the ioremap'd region is
++	 * smaller than the accessed offset. Extend the resource to TIS_MEM_LEN
++	 * here; the hardware always provides the full region at the standard
++	 * base address even when the BIOS under-declares it.
++	 */
++	if (resource_size(&tpm_info.res) < TIS_MEM_LEN) {
++		dev_info(&pnp_dev->dev,
++			 "tpm_tis: MMIO region too small (0x%llx), extending to 0x%x\n",
++			 (unsigned long long)resource_size(&tpm_info.res),
++			 TIS_MEM_LEN);
++		tpm_info.res.end = tpm_info.res.start + TIS_MEM_LEN - 1;
++	}
++
+ 	if (pnp_irq_valid(pnp_dev, 0))
+ 		tpm_info.irq = pnp_irq(pnp_dev, 0);
+ 	else
+--
+2.43.0

--- a/recipes-kernel/linux/linux-tb_6.13.bb
+++ b/recipes-kernel/linux/linux-tb_6.13.bb
@@ -20,6 +20,7 @@ SRC_URI = "\
     file://defconfig \
     file://debug.cfg \
     file://efi.cfg \
+    file://0001-tpm_tis-extend-mmio-region-to-cover-all-localities.patch \
 "
 SRCREV_machine = "dbbb5ef0d915435b20290766f99461e31c273b6c"
 SRCREV_meta = "49698cadd79745fa26aa7ef507c16902250c1750"

--- a/recipes-support/aem/aem_git.bb
+++ b/recipes-support/aem/aem_git.bb
@@ -11,11 +11,24 @@ SRCREV = "18a0a743462f50363ca83a9946bbc8b399a6e6da"
 
 S = "${WORKDIR}/git"
 
+FILES:${PN} += "${localstatedir}/lib/anti-evil-maid"
+
 do_install() {
-    install -d "${D}${sbindir}"
+    install -d "${D}${sbindir}" "${D}${localstatedir}/lib/anti-evil-maid"
     for file in "${S}/sbin"/*; do
         install -m 0755 "${file}" "${D}${sbindir}"
     done
 }
 
-RDEPENDS:${PN} += "bash gawk"
+# missing scrypt, oathtool
+RDEPENDS:${PN} += " \
+    coreutils \
+    gawk \
+    bash \
+    trousers-changer \
+    tpm-extra \
+    tpm-tools \
+    tpm2-tools \
+    qrencode \
+    openssl \
+"

--- a/recipes-support/aem/aem_git.bb
+++ b/recipes-support/aem/aem_git.bb
@@ -20,7 +20,6 @@ do_install() {
     done
 }
 
-# missing scrypt, oathtool
 RDEPENDS:${PN} += " \
     coreutils \
     gawk \
@@ -31,4 +30,6 @@ RDEPENDS:${PN} += " \
     tpm2-tools \
     qrencode \
     openssl \
+    scrypt \
+    oathtool \
 "

--- a/recipes-support/aem/aem_git.bb
+++ b/recipes-support/aem/aem_git.bb
@@ -10,17 +10,12 @@ SRC_URI = "git://github.com/TrenchBoot/qubes-antievilmaid.git;protocol=https;bra
 SRCREV = "18a0a743462f50363ca83a9946bbc8b399a6e6da"
 
 S = "${WORKDIR}/git"
-FILES:${PN} += "${sbindir}"
 
-ALLOW_EMPTY:${PN} = "1"
-
-inherit deploy
-
-do_deploy() {
-    install -d ${DEPLOYDIR}${sbindir}
-    for file in ${S}/sbin/*; do
-        install -m 0755 ${file} ${DEPLOYDIR}${sbindir}
+do_install() {
+    install -d "${D}${sbindir}"
+    for file in "${S}/sbin"/*; do
+        install -m 0755 "${file}" "${D}${sbindir}"
     done
 }
 
-addtask do_deploy after do_install
+RDEPENDS:${PN} += "bash gawk"

--- a/recipes-support/oathtool/oathtool_2.6.14.bb
+++ b/recipes-support/oathtool/oathtool_2.6.14.bb
@@ -1,0 +1,45 @@
+SUMMARY = "One-time password components"
+DESCRIPTION = " \
+    OATH Toolkit provides components for building one-time \
+    password authentication systems. It contains shared libraries, command line \
+    tools and a PAM module. Supported technologies include the event-based HOTP \
+    algorithm and the time-based TOTP algorithm. \
+"
+HOMEPAGE = "https://oath-toolkit.codeberg.page/"
+
+LICENSE = "GPL-3.0-or-later & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464 \
+    file://COPYING.LESSERv2;md5=4bf661c1e3793e55c8d1051bc5e0ae21 \
+"
+
+DEPENDS = "bison-native gengetopt-native"
+
+SRC_URI = " \
+    git://codeberg.org/oath-toolkit/oath-toolkit.git;name=oath-toolkit;protocol=https;branch=main \
+    git://github.com/coreutils/gnulib.git;name=gnulib;protocol=https;branch=stable-202601;destsuffix=gnulib \
+"
+
+SRCREV_oath-toolkit = "5a534218feaa1bf58b59bc183d7d4c34bc48c7c1"
+SRCREV_gnulib = "2a288c048e2a23ea9cd8cbef9a60aa4ac82bdc3d"
+SRCREV_FORMAT = "oath-toolkit_gnulib"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig gettext
+
+do_configure:prepend() {
+    export GNULIB_SRCDIR="${WORKDIR}/gnulib"
+    export PATH="${WORKDIR}/gnulib:${PATH}"
+    (cd "${S}" && ./bootstrap)
+}
+
+do_compile:prepend() {
+    export GNULIB_SRCDIR="${WORKDIR}/gnulib"
+    export PATH="${WORKDIR}/gnulib:${PATH}"
+
+    # help2man cannot run cross-compiled binaries, so provide a stub manpage
+    touch ${B}/oathtool/oathtool.1
+}
+
+EXTRA_OECONF = "--disable-pam --disable-pskc"

--- a/recipes-support/scrypt/scrypt_1.3.3.bb
+++ b/recipes-support/scrypt/scrypt_1.3.3.bb
@@ -1,0 +1,20 @@
+SUMMARY = "A simple password-based encryption utility"
+DESCRIPTION = " \
+    The scrypt key derivation function was originally developed \
+    for use in the Tarsnap online backup system and is designed to be far more \
+    secure against hardware brute-force attacks than alternative functions such \
+    as PBKDF2 or bcrypt. \
+"
+HOMEPAGE = "https://www.tarsnap.com/scrypt.html"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=f969c7aaa49089b1e5f2a7cba002f00f"
+
+DEPENDS = "openssl"
+
+SRC_URI = "git://github.com/Tarsnap/scrypt.git;protocol=https;branch=master"
+SRCREV = "041a2126130c3d1e7e2b8facb218c6c017b6890a"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig

--- a/recipes-support/tpm-extra/tpm-extra_git.bb
+++ b/recipes-support/tpm-extra/tpm-extra_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Additional tools not included in tpm-tools package."
+HOMEPAGE = "https://github.com/QubesOS/qubes-tpm-extra"
+
+LICENSE = "GPL-2.0-or-later"
+# There is no license file, but this one states "GPL" license.
+LIC_FILES_CHKSUM = "file://tpm-extra.spec.in;md5=baac70eb35980bb546ca2f3cc12ef4ae"
+
+DEPENDS += "trousers"
+SRC_URI = "git://github.com/QubesOS/qubes-tpm-extra.git;protocol=https;branch=main"
+SRCREV = "90d4421efcc6efedc91fa483d57167413831d0a2"
+
+S = "${WORKDIR}/git"
+
+do_compile() {
+    ${CC} ${CFLAGS} ${LDFLAGS} "${S}/tpm_pcr_extend.c" -ltspi -o "${B}/tpm_pcr_extend"
+}
+
+do_install() {
+    install -d "${D}${sbindir}"
+    install -m 0755 "${B}/tpm_pcr_extend" "${D}${sbindir}"
+    for file in "${S}/sbin"/*; do
+        install -m 0755 "${file}" "${D}${sbindir}"
+    done
+}
+
+RDEPENDS:${PN} += "bash trousers util-linux-unshare"

--- a/recipes-support/trousers-changer/trousers-changer_git.bb
+++ b/recipes-support/trousers-changer/trousers-changer_git.bb
@@ -1,0 +1,32 @@
+SUMMARY = "TPM service wrapper for portable installations"
+DESCRIPTION = " \
+    Wraps tcsd's systemd service to replace /var/lib/tmp with a symbolic link to \
+    /var/lib/tmps/TPMID/.  TPMID is read from an NVRAM entry provisioned from the \
+    outside (should be 20 bytes long). \
+    \
+    Can also be used to manage /var/lib/tpm for TPM2 as long as something will \
+    create files in /var/lib/tpm. \
+"
+
+HOMEPAGE = "https://github.com/QubesOS/qubes-trousers-changer"
+
+LICENSE = "GPL-2.0-or-later"
+# There is no license file, but this one states "GPL" license.
+LIC_FILES_CHKSUM = "file://trousers-changer.spec.in;md5=36377945ebeb7479328ed3c4e495b7b4"
+
+SRC_URI = "git://github.com/QubesOS/qubes-trousers-changer.git;protocol=https;branch=main"
+SRCREV = "5983773eb3624da0b7d591947d6e23dd748e61bd"
+
+S = "${WORKDIR}/git"
+
+FILES:${PN} += "${systemd_system_unitdir}/tcsd.service.d"
+
+do_install() {
+    install -d "${D}${sbindir}" "${D}${systemd_system_unitdir}/tcsd.service.d"
+    install -m 0755 "${S}/systemd/system/tcsd.service.d/trousers-changer.conf" "${D}${systemd_system_unitdir}/tcsd.service.d/trousers-changer.conf"
+    for file in "${S}/sbin"/*; do
+        install -m 0755 "${file}" "${D}${sbindir}"
+    done
+}
+
+RDEPENDS:${PN} += "bash trousers tpm-tools tpm2-tools tpm-extra psmisc"


### PR DESCRIPTION
* Add patch that fixes TPM driver panic on HP T630 (TPM 1.2, passing `tpm_tis.force=1` kernel arg also works).
* fix AEM recipe to install scripts in rootfs
* Add AEM script dependencies (still missing `oathtool` and `scrypt` used by `anti-evil-maid-install`)

`anti-evil-maid-tpm-setup` works (at least finishes without errors) on HP T630 with TPM1.2. On TPM2 there are segfault errors (only in dmesg):

```
[   28.801906] tpm2_nvreadpubl[539]: segfault at 5615282824f3 ip 00007f8780d18367 sp 00007fff3d6bc630 error 4 in libc.so.6[96367,7f8780ca6000+151000] likely on CPU 1 (core 1, socket 1)
[   28.807035] Code: 09 10 00 e8 6b d4 f9 ff 66 66 2e 0f 1f 84 00 00 00 00 00 f3 0f 1e fa 48 85 ff 0f 84 bb 00 00 00 55 48 8d 77 f0 53 48 83 ec 18 <48> 8b 47 f8 48 8b 1d 86 8a 13 00 a8 02 64 8b 2b 75 57 48 8b 15 18
[   28.986414] tpm2_nvreadpubl[554]: segfault at 55ae64651b57 ip 00007f982aae0367 sp 00007ffd03980b40 error 4 in libc.so.6[96367,7f982aa6e000+151000] likely on CPU 2 (core 2, socket 1)
[   28.989068] Code: 09 10 00 e8 6b d4 f9 ff 66 66 2e 0f 1f 84 00 00 00 00 00 f3 0f 1e fa 48 85 ff 0f 84 bb 00 00 00 55 48 8d 77 f0 53 48 83 ec 18 <48> 8b 47 f8 48 8b 1d 86 8a 13 00 a8 02 64 8b 2b 75 57 48 8b 15 18
```

but script finishes without returning error code:

```
anti-evil-maid-tpm-setup: Creating TPM ID...
anti-evil-maid-tpm-setup: Creating freshness token NVRAM area...
anti-evil-maid-tpm-setup: Generating TPM NVRAM area AUTHWRITE password
WARN: Reading full size of the NV index
```